### PR TITLE
Fix player reordering logic

### DIFF
--- a/state.js
+++ b/state.js
@@ -112,9 +112,10 @@ function ensurePlayerState(playerName) {
 function reorderPlayers(fromPlayer, toPlayer) {
   const fromIdx = state.players.indexOf(fromPlayer);
   const toIdx = state.players.indexOf(toPlayer);
-  if (fromIdx === -1 || toIdx === -1) return;
+  if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return;
   state.players.splice(fromIdx, 1);
-  state.players.splice(toIdx, 0, fromPlayer);
+  const insertIdx = fromIdx < toIdx ? toIdx : toIdx + 1;
+  state.players.splice(insertIdx, 0, fromPlayer);
   saveState();
 }
 

--- a/state.test.js
+++ b/state.test.js
@@ -66,6 +66,14 @@ describe('State Management', () => {
         expect(state.players).toEqual(['Player 2', 'Player 1']);
     });
 
+    test('should reorder players when moving later to earlier position', () => {
+        addPlayerToGame('Player A');
+        addPlayerToGame('Player B');
+        addPlayerToGame('Player C');
+        reorderPlayers('Player C', 'Player A');
+        expect(state.players).toEqual(['Player A', 'Player C', 'Player B']);
+    });
+
     test('should log a game', () => {
         logGame('Player 1', ['Player 1', 'Player 2'], { 'Player 1': 40, 'Player 2': 30 });
         const log = getGameLog();


### PR DESCRIPTION
## Summary
- fix incorrect insertion index when reordering players
- add regression test for reordering from later to earlier position

## Testing
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_685c8899e0f4832e891b5e603cb38542