### PR TITLE
Fix winner persistence across reloads

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -20,7 +20,13 @@ function createPlayerTile(playerName) {
     const { life, poison, dead } = state.playerState[playerName];
 
     const tile = document.createElement("div");
-    tile.className = `player-tile ${dead ? 'player-died' : ''}`;
+    const classes = ["player-tile"];
+    if (dead) classes.push("player-died");
+    if (state.gameEnded) classes.push("game-ended");
+    if (state.gameEnded && state.winner === playerName) {
+        classes.push("winner-tile");
+    }
+    tile.className = classes.join(" ");
     tile.dataset.player = playerName;
     tile.setAttribute("draggable", "true");
 
@@ -94,7 +100,7 @@ function createPlayerTile(playerName) {
     tile.appendChild(lifeSection);
     tile.appendChild(actions);
 
-    if (dead) {
+    if (dead || state.gameEnded) {
         tile.querySelectorAll("button").forEach((btn) => (btn.disabled = true));
     }
 

--- a/ui.test.js
+++ b/ui.test.js
@@ -75,4 +75,25 @@ describe('UI Management', () => {
         const btn = document.getElementById('add-player-btn');
         expect(btn.style.display).toBe('none');
     });
+
+    test('should display winner state after reload', () => {
+        state.players = ['Alice', 'Bob'];
+        state.playerState = {
+            'Alice': { life: 20, poison: 0, dead: false },
+            'Bob': { life: 15, poison: 0, dead: false },
+        };
+        state.gameEnded = true;
+        state.winner = 'Alice';
+        updateCurrentGamePlayersUI();
+        const tiles = document.getElementById('player-tiles').children;
+        const aliceTile = Array.from(tiles).find(t => t.dataset.player === 'Alice');
+        const bobTile = Array.from(tiles).find(t => t.dataset.player === 'Bob');
+        expect(aliceTile.classList.contains('winner-tile')).toBe(true);
+        expect(aliceTile.classList.contains('game-ended')).toBe(true);
+        expect(bobTile.classList.contains('winner-tile')).toBe(false);
+        expect(bobTile.classList.contains('game-ended')).toBe(true);
+        Array.from(aliceTile.querySelectorAll('button')).forEach(btn => {
+            expect(btn.disabled).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- carry over game win state after reloading
- update UI tests for winner persistence

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_685c8a364348832ea2494913fc58aabe