### PR TITLE
Add remove player option

### DIFF
--- a/events.js
+++ b/events.js
@@ -211,6 +211,17 @@ async function markPlayerAsDied(playerName) {
     saveState();
 }
 
+async function removePlayerFromGameUI(playerName) {
+    const confirmed = await showConfirm(
+        `Remove "${playerName}" from the current game?`,
+        "Remove Player"
+    );
+    if (!confirmed) return;
+    removePlayerFromGame(playerName);
+    updateCurrentGamePlayersUI();
+    updateAddPlayerBtnVisibility();
+}
+
 async function startNewGame() {
     const confirmed = await showConfirm(
         "This will clear the current game.",
@@ -334,6 +345,8 @@ function initEventListeners() {
             openPoisonModal(playerName);
         } else if (target.closest(".mark-died-btn")) {
             markPlayerAsDied(playerName);
+        } else if (target.closest(".remove-player-btn")) {
+            removePlayerFromGameUI(playerName);
         }
     });
 

--- a/state.js
+++ b/state.js
@@ -97,6 +97,13 @@ function removePlayerFromGame(playerName) {
   const idx = state.players.indexOf(playerName);
   if (idx !== -1) {
     state.players.splice(idx, 1);
+    delete state.playerState[playerName];
+    delete state.commanderDamage[playerName];
+    for (const p of Object.keys(state.commanderDamage)) {
+      if (state.commanderDamage[p]) {
+        delete state.commanderDamage[p][playerName];
+      }
+    }
     saveState();
     return true;
   }

--- a/style.css
+++ b/style.css
@@ -431,7 +431,8 @@ main {
 
 .commander-damage-btn,
 .poison-btn,
-.mark-died-btn {
+.mark-died-btn,
+.remove-player-btn {
   background: #d8d8da;
   border: none;
   border-radius: 50%;
@@ -464,7 +465,9 @@ main {
 }
 
 .mark-died-btn:hover,
-.mark-died-btn:focus {
+.mark-died-btn:focus,
+.remove-player-btn:hover,
+.remove-player-btn:focus {
   background: #fee2e2;
   color: #e11d48;
   transform: scale(1.08);

--- a/ui.js
+++ b/ui.js
@@ -92,9 +92,16 @@ function createPlayerTile(playerName) {
     diedBtn.setAttribute("aria-label", "Mark as Died");
     diedBtn.textContent = "☠️";
 
+    const removeBtn = document.createElement("button");
+    removeBtn.className = "remove-player-btn";
+    removeBtn.title = "Remove Player";
+    removeBtn.setAttribute("aria-label", "Remove Player");
+    removeBtn.textContent = "✖";
+
     actions.appendChild(commanderBtn);
     actions.appendChild(poisonBtn);
     actions.appendChild(diedBtn);
+    actions.appendChild(removeBtn);
 
     tile.appendChild(header);
     tile.appendChild(lifeSection);


### PR DESCRIPTION
## Summary
- allow removing players from the current game
- show a remove button on each player tile
- handle remove action in event handlers
- clean up player data when a player is removed

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_685c8c43bb74832ea0e1759ecfa7477e