### PR TITLE
Fix mobile input focus in modal

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -268,7 +268,9 @@ function showModal(modalId) {
         const focusable = modal.querySelector(
             'button, [tabindex]:not([tabindex="-1"]), input, select, textarea, a[href]'
         );
-        if (focusable) focusable.focus();
+        if (focusable) {
+            setTimeout(() => focusable.focus(), 50);
+        }
         modal.setAttribute("aria-modal", "true");
         modal.setAttribute("role", "dialog");
     }

--- a/ui.test.js
+++ b/ui.test.js
@@ -55,6 +55,15 @@ describe('UI Management', () => {
         expect(overlay.hidden).toBe(true);
     });
 
+    test('new player modal should focus input', () => {
+        jest.useFakeTimers();
+        showModal('new-player-modal');
+        jest.advanceTimersByTime(60);
+        const input = document.getElementById('new-player-input');
+        expect(document.activeElement).toBe(input);
+        jest.useRealTimers();
+    });
+
     test('should show an input error', () => {
         showInputError('Test error');
         const error = document.getElementById('new-player-error');


### PR DESCRIPTION
## Summary
- ensure modal focus happens after animation
- test that new player modal focuses input

## Testing
- `npm test` *(fails: Cannot find module '/workspace/CommanderLifeTracker/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_b_685cb06dc860832eb5dff723d01d2abe