### PR TITLE
Fix PWA new player input

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -269,7 +269,15 @@ function showModal(modalId) {
             'button, [tabindex]:not([tabindex="-1"]), input, select, textarea, a[href]'
         );
         if (focusable) {
-            setTimeout(() => focusable.focus(), 50);
+            const standalone =
+                (window.matchMedia &&
+                    window.matchMedia('(display-mode: standalone)').matches) ||
+                window.navigator.standalone;
+            if (standalone) {
+                focusable.focus();
+            } else {
+                setTimeout(() => focusable.focus(), 50);
+            }
         }
         modal.setAttribute("aria-modal", "true");
         modal.setAttribute("role", "dialog");

--- a/ui.test.js
+++ b/ui.test.js
@@ -55,13 +55,20 @@ describe('UI Management', () => {
         expect(overlay.hidden).toBe(true);
     });
 
-    test('new player modal should focus input', () => {
+    test('new player modal should focus input after delay', () => {
         jest.useFakeTimers();
         showModal('new-player-modal');
         jest.advanceTimersByTime(60);
         const input = document.getElementById('new-player-input');
         expect(document.activeElement).toBe(input);
         jest.useRealTimers();
+    });
+
+    test('new player modal should focus input immediately in standalone mode', () => {
+        window.matchMedia = jest.fn().mockReturnValue({ matches: true });
+        showModal('new-player-modal');
+        const input = document.getElementById('new-player-input');
+        expect(document.activeElement).toBe(input);
     });
 
     test('should show an input error', () => {


### PR DESCRIPTION
## Summary
- ensure modals delay focus on desktop
- focus immediately for standalone PWA
- expand tests for standalone behavior

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_685cbb95313c832ea8750a856154d10b