### PR TITLE
Fix life totals in game log

### DIFF
--- a/events.js
+++ b/events.js
@@ -68,7 +68,11 @@ async function declareWinner(playerName) {
     state.gameEnded = true;
     state.winner = playerName;
 
-    logGame(playerName, state.players, state.playerState);
+    const finalLife = {};
+    state.players.forEach((p) => {
+        finalLife[p] = state.playerState[p]?.life || 0;
+    });
+    logGame(playerName, state.players, finalLife);
 
     document.querySelectorAll(".player-tile").forEach((tile) => {
         tile.classList.add("game-ended");

--- a/state.js
+++ b/state.js
@@ -127,12 +127,19 @@ function reorderPlayers(fromPlayer, toPlayer) {
 }
 
 function logGame(winnerName, playersInGame, finalLifeTotals) {
+    const lifeTotalsSnapshot = {};
+    playersInGame.forEach((p) => {
+        const val = finalLifeTotals[p];
+        lifeTotalsSnapshot[p] =
+            val && typeof val === "object" ? val.life : val;
+    });
+
     const log = JSON.parse(localStorage.getItem(GAME_LOG_KEY) || "[]");
     log.push({
         id: Date.now(),
         winner: winnerName,
         players: playersInGame,
-        lifeTotals: finalLifeTotals,
+        lifeTotals: lifeTotalsSnapshot,
         endedAt: new Date().toISOString(),
     });
     localStorage.setItem(GAME_LOG_KEY, JSON.stringify(log));

--- a/ui.js
+++ b/ui.js
@@ -238,11 +238,18 @@ function renderGameLog() {
             details.className = "game-log-details";
             details.textContent = `Players: ${entry.players.join(", ")}`;
 
-            const lifeTotals = document.createElement("div");
-            lifeTotals.className = "game-log-details";
-            lifeTotals.textContent =
-                "Final Life: " +
-                entry.players.map((p) => `${p}: ${entry.lifeTotals[p]}`).join(", ");
+        const lifeTotals = document.createElement("div");
+        lifeTotals.className = "game-log-details";
+        lifeTotals.textContent =
+            "Final Life: " +
+            entry.players
+                .map((p) => {
+                    const val = entry.lifeTotals[p];
+                    return `${p}: ${
+                        val && typeof val === "object" ? val.life : val
+                    }`;
+                })
+                .join(", ");
 
             const delBtn = document.createElement("button");
             delBtn.className = "delete-game-log-btn";


### PR DESCRIPTION
## Summary
- record only numeric life totals in the game log
- capture life totals when declaring a winner
- display life totals correctly in the log view even for old entries

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_6860180c9400832e8a52b75743cea068