### PR TITLE
Fix drag reorder for player tiles

### DIFF
--- a/state.js
+++ b/state.js
@@ -120,9 +120,9 @@ function reorderPlayers(fromPlayer, toPlayer) {
   const fromIdx = state.players.indexOf(fromPlayer);
   const toIdx = state.players.indexOf(toPlayer);
   if (fromIdx === -1 || toIdx === -1 || fromIdx === toIdx) return;
-  state.players.splice(fromIdx, 1);
-  const insertIdx = fromIdx < toIdx ? toIdx : toIdx + 1;
-  state.players.splice(insertIdx, 0, fromPlayer);
+  const temp = state.players[fromIdx];
+  state.players[fromIdx] = state.players[toIdx];
+  state.players[toIdx] = temp;
   saveState();
 }
 

--- a/state.test.js
+++ b/state.test.js
@@ -66,12 +66,12 @@ describe('State Management', () => {
         expect(state.players).toEqual(['Player 2', 'Player 1']);
     });
 
-    test('should reorder players when moving later to earlier position', () => {
+    test('should swap players when moving later to earlier position', () => {
         addPlayerToGame('Player A');
         addPlayerToGame('Player B');
         addPlayerToGame('Player C');
         reorderPlayers('Player C', 'Player A');
-        expect(state.players).toEqual(['Player A', 'Player C', 'Player B']);
+        expect(state.players).toEqual(['Player C', 'Player B', 'Player A']);
     });
 
     test('should log a game', () => {


### PR DESCRIPTION
## Summary
- fix player reorder logic to swap positions
- update unit test for new swap behavior

## Testing
- `npm test --silent` *(fails: Cannot find module '/workspace/CommanderLifeTracker/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_b_6860183a785c832e9d21ead36a644b1e