### PR TITLE
Add commander damage indicator

### DIFF
--- a/events.js
+++ b/events.js
@@ -24,6 +24,7 @@ import {
     showInputError,
     clearInputError,
     updateAddPlayerBtnVisibility,
+    updateCommanderDamageIndicator,
 } from "./ui.js";
 
 function handleSaveNewPlayer() {
@@ -125,6 +126,7 @@ function changeCommanderDamage(player, opponent, delta) {
         );
         if (tile) tile.classList.remove("commander-lethal");
     }
+    updateCommanderDamageIndicator(player);
     saveState();
 }
 

--- a/style.css
+++ b/style.css
@@ -448,6 +448,18 @@ main {
   box-shadow: 0 1px 4px rgba(30, 41, 59, 0.07);
   user-select: none;
   touch-action: manipulation;
+  position: relative;
+}
+
+.commander-damage-btn.has-commander-damage::after {
+  content: "";
+  position: absolute;
+  top: 0.25em;
+  right: 0.25em;
+  width: 0.6em;
+  height: 0.6em;
+  background: #f87171;
+  border-radius: 50%;
 }
 
 .commander-damage-btn:hover,

--- a/ui.js
+++ b/ui.js
@@ -79,6 +79,10 @@ function createPlayerTile(playerName) {
     commanderBtn.title = "Commander Damage";
     commanderBtn.setAttribute("aria-label", "Commander Damage");
     commanderBtn.textContent = "⚔️";
+    const dmgRec = state.commanderDamage[playerName] || {};
+    if (Object.values(dmgRec).some((v) => v > 0)) {
+        commanderBtn.classList.add("has-commander-damage");
+    }
 
     const poisonBtn = document.createElement("button");
     poisonBtn.className = "poison-btn";
@@ -350,6 +354,20 @@ function updateAddPlayerBtnVisibility() {
     addPlayerBtn.style.display = state.gameEnded ? "none" : "";
 }
 
+function updateCommanderDamageIndicator(playerName) {
+    const btn = document.querySelector(
+        `.player-tile[data-player="${playerName}"] .commander-damage-btn`
+    );
+    if (!btn) return;
+    const record = state.commanderDamage[playerName] || {};
+    const hasDmg = Object.values(record).some((v) => v > 0);
+    if (hasDmg) {
+        btn.classList.add("has-commander-damage");
+    } else {
+        btn.classList.remove("has-commander-damage");
+    }
+}
+
 export {
     initUI,
     createPlayerTile,
@@ -363,4 +381,5 @@ export {
     showInputError,
     clearInputError,
     updateAddPlayerBtnVisibility,
+    updateCommanderDamageIndicator,
 };

--- a/ui.test.js
+++ b/ui.test.js
@@ -1,7 +1,7 @@
 
 import { jest } from '@jest/globals';
 import { state } from './state.js';
-import { initUI, createPlayerTile, updateCurrentGamePlayersUI, showModal, hideModal, showInputError, clearInputError, updateAddPlayerBtnVisibility } from './ui.js';
+import { initUI, createPlayerTile, updateCurrentGamePlayersUI, showModal, hideModal, showInputError, clearInputError, updateAddPlayerBtnVisibility, updateCommanderDamageIndicator } from './ui.js';
 
 describe('UI Management', () => {
     beforeEach(() => {
@@ -84,6 +84,18 @@ describe('UI Management', () => {
         clearInputError();
         const error = document.getElementById('new-player-error');
         expect(error).toBeNull();
+    });
+
+    test('commander damage indicator updates', () => {
+        state.players = ['Alice'];
+        state.playerState = { 'Alice': { life: 40, poison: 0, dead: false } };
+        state.commanderDamage = { 'Alice': { Bob: 0 } };
+        updateCurrentGamePlayersUI();
+        const btn = document.querySelector('.commander-damage-btn');
+        expect(btn.classList.contains('has-commander-damage')).toBe(false);
+        state.commanderDamage['Alice'].Bob = 5;
+        updateCommanderDamageIndicator('Alice');
+        expect(btn.classList.contains('has-commander-damage')).toBe(true);
     });
 
     test('should update the add player button visibility', () => {


### PR DESCRIPTION
## Summary
- highlight commander damage icon when player has received any
- expose helper to refresh commander damage indicator
- show commander damage indicator on tile when damage exists
- test the indicator updates

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_68642758fc84832e92eeff5f51bad458