### PR TITLE
Fix Mark Player Dead Cancel

### DIFF
--- a/events.js
+++ b/events.js
@@ -344,7 +344,7 @@ function initEventListeners() {
 
     document.getElementById("close-settings-btn").addEventListener("click", hideModal);
 
-    document.getElementById("player-tiles").addEventListener("click", (e) => {
+    document.getElementById("player-tiles").addEventListener("click", async (e) => {
         const target = e.target;
         const tile = target.closest(".player-tile");
         if (!tile) return;
@@ -361,7 +361,13 @@ function initEventListeners() {
         } else if (target.closest(".poison-btn")) {
             openPoisonModal(playerName);
         } else if (target.closest(".mark-died-btn")) {
-            markPlayerAsDied(playerName);
+            const confirmed = await showConfirm(
+                `Mark "${playerName}" as dead?`,
+                "Mark Player Dead"
+            );
+            if (confirmed) {
+                markPlayerAsDied(playerName);
+            }
         } else if (target.closest(".remove-player-btn")) {
             removePlayerFromGameUI(playerName);
         }


### PR DESCRIPTION
## Summary
- ask for confirmation before marking a player as dead
- only mark the player dead if the confirm dialog is accepted

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_687d1d3d7368832eae7d76aacca1e90c