### PR TITLE
Enable Node built-in test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Track your life totals when playing Magic the Gathering Commander (aka EDH).",
   "main": "app.js",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/state.test.js
+++ b/state.test.js
@@ -1,91 +1,114 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  state,
+  saveState,
+  loadState,
+  getSavedPlayers,
+  savePlayer,
+  removePlayer,
+  setDefaultPlayer,
+  getDefaultPlayer,
+  addPlayerToGame,
+  removePlayerFromGame,
+  ensurePlayerState,
+  reorderPlayers,
+  logGame,
+  getGameLog,
+  deleteGameLogEntry,
+} from './state.js';
 
-import { state, saveState, loadState, getSavedPlayers, savePlayer, removePlayer, setDefaultPlayer, getDefaultPlayer, addPlayerToGame, removePlayerFromGame, ensurePlayerState, reorderPlayers, logGame, getGameLog, deleteGameLogEntry } from './state.js';
+class LocalStorageMock {
+  constructor() { this.store = {}; }
+  clear() { this.store = {}; }
+  getItem(k) { return Object.prototype.hasOwnProperty.call(this.store, k) ? this.store[k] : null; }
+  setItem(k,v) { this.store[k] = String(v); }
+  removeItem(k) { delete this.store[k]; }
+}
+
+global.localStorage = new LocalStorageMock();
 
 describe('State Management', () => {
-    beforeEach(() => {
-        localStorage.clear();
-        state.players = [];
-        state.playerState = {};
-        state.gameEnded = false;
-        state.winner = null;
-    });
+  beforeEach(() => {
+    global.localStorage.clear();
+    state.players = [];
+    state.playerState = {};
+    state.gameEnded = false;
+    state.winner = null;
+  });
 
-    test('should save and load state', () => {
-        state.players = ['Player 1'];
-        state.playerState = { 'Player 1': { life: 40, poison: 0, dead: false } };
-        saveState();
-        state.players = [];
-        state.playerState = {};
-        loadState();
-        expect(state.players).toEqual(['Player 1']);
-        expect(state.playerState).toEqual({ 'Player 1': { life: 40, poison: 0, dead: false } });
-    });
+  it('should save and load state', () => {
+    state.players = ['Player 1'];
+    state.playerState = { 'Player 1': { life: 40, poison: 0, dead: false } };
+    saveState();
+    state.players = [];
+    state.playerState = {};
+    loadState();
+    assert.deepStrictEqual(state.players, ['Player 1']);
+    assert.deepStrictEqual(state.playerState, { 'Player 1': { life: 40, poison: 0, dead: false } });
+  });
 
-    test('should save and get players', () => {
-        savePlayer('Player 1');
-        savePlayer('Player 2');
-        const players = getSavedPlayers();
-        expect(players).toEqual(['Player 1', 'Player 2']);
-    });
+  it('should save and get players', () => {
+    savePlayer('Player 1');
+    savePlayer('Player 2');
+    assert.deepStrictEqual(getSavedPlayers(), ['Player 1', 'Player 2']);
+  });
 
-    test('should remove a player', () => {
-        savePlayer('Player 1');
-        savePlayer('Player 2');
-        removePlayer('Player 1');
-        const players = getSavedPlayers();
-        expect(players).toEqual(['Player 2']);
-    });
+  it('should remove a player', () => {
+    savePlayer('Player 1');
+    savePlayer('Player 2');
+    removePlayer('Player 1');
+    assert.deepStrictEqual(getSavedPlayers(), ['Player 2']);
+  });
 
-    test('should set and get the default player', () => {
-        setDefaultPlayer('Player 1');
-        const defaultPlayer = getDefaultPlayer();
-        expect(defaultPlayer).toBe('Player 1');
-    });
+  it('should set and get the default player', () => {
+    setDefaultPlayer('Player 1');
+    assert.strictEqual(getDefaultPlayer(), 'Player 1');
+  });
 
-    test('should add a player to the game', () => {
-        addPlayerToGame('Player 1');
-        expect(state.players).toEqual(['Player 1']);
-    });
+  it('should add a player to the game', () => {
+    addPlayerToGame('Player 1');
+    assert.deepStrictEqual(state.players, ['Player 1']);
+  });
 
-    test('should remove a player from the game', () => {
-        addPlayerToGame('Player 1');
-        addPlayerToGame('Player 2');
-        removePlayerFromGame('Player 1');
-        expect(state.players).toEqual(['Player 2']);
-    });
+  it('should remove a player from the game', () => {
+    addPlayerToGame('Player 1');
+    addPlayerToGame('Player 2');
+    removePlayerFromGame('Player 1');
+    assert.deepStrictEqual(state.players, ['Player 2']);
+  });
 
-    test('should ensure player state', () => {
-        ensurePlayerState('Player 1');
-        expect(state.playerState['Player 1']).toEqual({ life: 40, poison: 0, dead: false });
-    });
+  it('should ensure player state', () => {
+    ensurePlayerState('Player 1');
+    assert.deepStrictEqual(state.playerState['Player 1'], { life: 40, poison: 0, dead: false });
+  });
 
-    test('should reorder players', () => {
-        addPlayerToGame('Player 1');
-        addPlayerToGame('Player 2');
-        reorderPlayers('Player 1', 'Player 2');
-        expect(state.players).toEqual(['Player 2', 'Player 1']);
-    });
+  it('should reorder players', () => {
+    addPlayerToGame('Player 1');
+    addPlayerToGame('Player 2');
+    reorderPlayers('Player 1', 'Player 2');
+    assert.deepStrictEqual(state.players, ['Player 2', 'Player 1']);
+  });
 
-    test('should swap players when moving later to earlier position', () => {
-        addPlayerToGame('Player A');
-        addPlayerToGame('Player B');
-        addPlayerToGame('Player C');
-        reorderPlayers('Player C', 'Player A');
-        expect(state.players).toEqual(['Player C', 'Player B', 'Player A']);
-    });
+  it('should swap players when moving later to earlier position', () => {
+    addPlayerToGame('Player A');
+    addPlayerToGame('Player B');
+    addPlayerToGame('Player C');
+    reorderPlayers('Player C', 'Player A');
+    assert.deepStrictEqual(state.players, ['Player C', 'Player B', 'Player A']);
+  });
 
-    test('should log a game', () => {
-        logGame('Player 1', ['Player 1', 'Player 2'], { 'Player 1': 40, 'Player 2': 30 });
-        const log = getGameLog();
-        expect(log.length).toBe(1);
-        expect(log[0].winner).toBe('Player 1');
-    });
+  it('should log a game', () => {
+    logGame('Player 1', ['Player 1', 'Player 2'], { 'Player 1': 40, 'Player 2': 30 });
+    const log = getGameLog();
+    assert.strictEqual(log.length, 1);
+    assert.strictEqual(log[0].winner, 'Player 1');
+  });
 
-    test('should delete a game log entry', () => {
-        logGame('Player 1', ['Player 1', 'Player 2'], { 'Player 1': 40, 'Player 2': 30 });
-        const log = getGameLog();
-        deleteGameLogEntry(log[0].id);
-        const newLog = getGameLog();
-        expect(newLog.length).toBe(0);
-    });
+  it('should delete a game log entry', () => {
+    logGame('Player 1', ['Player 1', 'Player 2'], { 'Player 1': 40, 'Player 2': 30 });
+    const log = getGameLog();
+    deleteGameLogEntry(log[0].id);
+    assert.strictEqual(getGameLog().length, 0);
+  });
 });

--- a/test/dom.js
+++ b/test/dom.js
@@ -1,0 +1,189 @@
+class ClassList {
+  constructor() { this.set = new Set(); }
+  add(...cls) { cls.forEach(c => this.set.add(c)); }
+  remove(...cls) { cls.forEach(c => this.set.delete(c)); }
+  contains(c) { return this.set.has(c); }
+  get value() { return Array.from(this.set).join(' '); }
+}
+
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.id = '';
+    this.classList = new ClassList();
+    this.dataset = {};
+    this.attributes = {};
+    this.style = {};
+    this.children = [];
+    this.parentNode = null;
+    this._text = '';
+    this.hidden = false;
+    this.disabled = false;
+    this.eventListeners = {};
+  }
+
+  get className() {
+    return this.classList.value;
+  }
+  set className(v) {
+    this.classList = new ClassList();
+    if (v && v.trim()) {
+      this.classList.add(...v.trim().split(/\s+/));
+    }
+  }
+
+  get textContent() {
+    return this._text;
+  }
+  set textContent(v) {
+    this._text = String(v);
+  }
+  appendChild(el) {
+    el.parentNode = this;
+    this.children.push(el);
+    return el;
+  }
+  insertBefore(newNode, refNode) {
+    const idx = this.children.indexOf(refNode);
+    if (idx === -1) return this.appendChild(newNode);
+    newNode.parentNode = this;
+    this.children.splice(idx, 0, newNode);
+    return newNode;
+  }
+  removeChild(el) {
+    const idx = this.children.indexOf(el);
+    if (idx !== -1) {
+      this.children.splice(idx, 1);
+      el.parentNode = null;
+    }
+  }
+  remove() {
+    if (this.parentNode) this.parentNode.removeChild(this);
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    if (name === 'id') this.id = String(value);
+    if (name === 'class') this.classList.add(...String(value).split(/\s+/));
+    if (name.startsWith('data-')) this.dataset[name.slice(5)] = String(value);
+  }
+  getAttribute(name) {
+    return this.attributes[name];
+  }
+  removeAttribute(name) {
+    delete this.attributes[name];
+    if (name === 'id') this.id = '';
+  }
+  addEventListener(event, handler) {
+    if (!this.eventListeners[event]) this.eventListeners[event] = [];
+    this.eventListeners[event].push(handler);
+  }
+  removeEventListener(event, handler) {
+    if (!this.eventListeners[event]) return;
+    this.eventListeners[event] = this.eventListeners[event].filter(h => h !== handler);
+  }
+  focus() { if (global.document) global.document.activeElement = this; }
+
+  querySelector(selector) {
+    const res = this.querySelectorAll(selector);
+    return res[0] || null;
+  }
+
+  querySelectorAll(selector) {
+    const groups = selector.split(',').map(s => s.trim()).filter(Boolean);
+    const results = [];
+    for (const group of groups) {
+      const parts = group.split(/\s+/).map(parseSimpleSelector);
+      results.push(...queryAll(this, parts));
+    }
+    return results;
+  }
+}
+
+function traverse(root, cb) {
+  for (const child of root.children) {
+    if (cb(child) === false) continue;
+    traverse(child, cb);
+  }
+}
+
+function parseSimpleSelector(token) {
+  const result = { tag:null, id:null, classes:[], attrs:{} };
+  let t = token;
+  let m;
+  if ((m = t.match(/^([a-zA-Z]+)/))) {
+    result.tag = m[1].toUpperCase();
+    t = t.slice(m[1].length);
+  }
+  while ((m = t.match(/^#([a-zA-Z0-9_-]+)/))) {
+    result.id = m[1];
+    t = t.slice(m[0].length);
+  }
+  while ((m = t.match(/^\.([a-zA-Z0-9_-]+)/))) {
+    result.classes.push(m[1]);
+    t = t.slice(m[0].length);
+  }
+  while ((m = t.match(/^\[([a-zA-Z0-9_-]+)(?:="([^"]*)")?\]/))) {
+    result.attrs[m[1]] = m[2] || null;
+    t = t.slice(m[0].length);
+  }
+  return result;
+}
+
+function elementMatches(el, sel) {
+  if (sel.tag && el.tagName !== sel.tag) return false;
+  if (sel.id && el.id !== sel.id) return false;
+  for (const cls of sel.classes) if (!el.classList.contains(cls)) return false;
+  for (const [k,v] of Object.entries(sel.attrs)) {
+    const val = k.startsWith('data-') ? el.dataset[k.slice(5)] : el.attributes[k];
+    if (v != null) { if (val !== v) return false; } else { if (val == null) return false; }
+  }
+  return true;
+}
+
+function queryAll(root, selectors, idx=0) {
+  const sel = selectors[idx];
+  const matches = [];
+  traverse(root, el => {
+    if (elementMatches(el, sel)) matches.push(el);
+  });
+  if (idx === selectors.length - 1) return matches;
+  const results = [];
+  for (const el of matches) {
+    results.push(...queryAll(el, selectors, idx+1));
+  }
+  return results;
+}
+
+class Document {
+  constructor() {
+    this.body = new Element('body');
+    this.activeElement = null;
+  }
+  createElement(tagName) { return new Element(tagName); }
+  getElementById(id) {
+    let found = null;
+    traverse(this.body, el => { if (el.id === id) { found = el; return false; } });
+    return found;
+  }
+  querySelector(selector) {
+    const res = this.querySelectorAll(selector);
+    return res[0] || null;
+  }
+  querySelectorAll(selector) {
+    const groups = selector.split(',').map(s => s.trim()).filter(Boolean);
+    const results = [];
+    for (const group of groups) {
+      const parts = group.split(/\s+/).map(parseSimpleSelector);
+      results.push(...queryAll(this.body, parts));
+    }
+    return results;
+  }
+}
+
+function createDOM() {
+  const doc = new Document();
+  global.document = doc;
+  return doc;
+}
+
+export { Element, Document, createDOM };

--- a/ui.test.js
+++ b/ui.test.js
@@ -1,128 +1,171 @@
-
-import { jest } from '@jest/globals';
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
 import { state } from './state.js';
-import { initUI, createPlayerTile, updateCurrentGamePlayersUI, showModal, hideModal, showInputError, clearInputError, updateAddPlayerBtnVisibility, updateCommanderDamageIndicator } from './ui.js';
+import {
+  initUI,
+  createPlayerTile,
+  updateCurrentGamePlayersUI,
+  showModal,
+  hideModal,
+  showInputError,
+  clearInputError,
+  updateAddPlayerBtnVisibility,
+  updateCommanderDamageIndicator,
+} from './ui.js';
+import { createDOM } from './test/dom.js';
+import { setTimeout as delay } from 'node:timers/promises';
+
+function setupDOM() {
+  const doc = createDOM();
+  const ids = [
+    'player-tiles',
+    'saved-players-list',
+    'settings-players-list',
+    'game-log-list',
+    'modal-overlay',
+    'add-player-modal',
+    'new-player-modal',
+    'confirm-modal',
+    'confirm-modal-title',
+    'confirm-modal-message',
+    'confirm-modal-ok',
+    'confirm-modal-cancel',
+    'add-player-btn',
+  ];
+  ids.forEach(id => {
+    const el = doc.createElement('div');
+    el.id = id;
+    if (id === 'add-player-modal' || id === 'new-player-modal' || id === 'confirm-modal') {
+      el.classList.add('modal');
+      el.hidden = true;
+    }
+    doc.body.appendChild(el);
+  });
+  const input = doc.createElement('input');
+  input.id = 'new-player-input';
+  doc.getElementById('new-player-modal').appendChild(input);
+  return doc;
+}
+
+class LocalStorageMock {
+  constructor() { this.store = {}; }
+  clear() { this.store = {}; }
+  getItem(k) { return Object.prototype.hasOwnProperty.call(this.store, k) ? this.store[k] : null; }
+  setItem(k,v) { this.store[k] = String(v); }
+  removeItem(k) { delete this.store[k]; }
+}
+
+global.window = { matchMedia: () => ({ matches: false }), navigator: {} };
+global.localStorage = new LocalStorageMock();
 
 describe('UI Management', () => {
-    beforeEach(() => {
-        document.body.innerHTML = `
-            <div id="player-tiles"></div>
-            <div id="saved-players-list"></div>
-            <div id="settings-players-list"></div>
-            <div id="game-log-list"></div>
-            <div id="modal-overlay" hidden></div>
-            <div id="add-player-modal" class="modal" hidden></div>
-            <div id="new-player-modal" class="modal" hidden><input id="new-player-input" /></div>' +
-            <div id="confirm-modal" class="modal" hidden>
-                <div id="confirm-modal-title"></div>
-                <div id="confirm-modal-message"></div>
-                <button id="confirm-modal-ok"></button>
-                <button id="confirm-modal-cancel"></button>
-            </div>
-            <button id="add-player-btn"></button>
-        `;
+  beforeEach(() => {
+    const doc = setupDOM();
+    global.document = doc;
+    state.players = [];
+    state.playerState = {};
+    state.gameEnded = false;
+    state.commanderDamage = {};
+    state.winner = null;
+    initUI();
+  });
 
-        state.players = [];
-        state.playerState = {};
-        state.gameEnded = false;
-        initUI();
-    });
+  it('should create a player tile', () => {
+    state.playerState['Player 1'] = { life: 40, poison: 0, dead: false };
+    const tile = createPlayerTile('Player 1');
+    assert.ok(tile);
+    assert.strictEqual(tile.dataset.player, 'Player 1');
+    const life = tile.querySelector('.life-total');
+    assert.strictEqual(life.textContent, '40');
+  });
 
-    test('should create a player tile', () => {
-        state.playerState['Player 1'] = { life: 40, poison: 0, dead: false };
-        const tile = createPlayerTile('Player 1');
-        expect(tile).not.toBeNull();
-        expect(tile.dataset.player).toBe('Player 1');
-        expect(tile.querySelector('.life-total').textContent).toBe('40');
-    });
+  it('should update the current game players UI', () => {
+    state.players = ['Player 1'];
+    state.playerState = { 'Player 1': { life: 40, poison: 0, dead: false } };
+    updateCurrentGamePlayersUI();
+    const tiles = document.getElementById('player-tiles');
+    assert.strictEqual(tiles.children.length, 1);
+    assert.strictEqual(tiles.children[0].dataset.player, 'Player 1');
+  });
 
-    test('should update the current game players UI', () => {
-        state.players = ['Player 1'];
-        state.playerState = { 'Player 1': { life: 40, poison: 0, dead: false } };
-        updateCurrentGamePlayersUI();
-        const tiles = document.getElementById('player-tiles');
-        expect(tiles.children.length).toBe(1);
-        expect(tiles.children[0].dataset.player).toBe('Player 1');
-    });
+  it('should show and hide a modal', () => {
+    showModal('add-player-modal');
+    const modal = document.getElementById('add-player-modal');
+    const overlay = document.getElementById('modal-overlay');
+    assert.strictEqual(modal.hidden, false);
+    assert.strictEqual(overlay.hidden, false);
+    hideModal();
+    assert.strictEqual(modal.hidden, true);
+    assert.strictEqual(overlay.hidden, true);
+  });
 
-    test('should show and hide a modal', () => {
-        showModal('add-player-modal');
-        const modal = document.getElementById('add-player-modal');
-        const overlay = document.getElementById('modal-overlay');
-        expect(modal.hidden).toBe(false);
-        expect(overlay.hidden).toBe(false);
-        hideModal();
-        expect(modal.hidden).toBe(true);
-        expect(overlay.hidden).toBe(true);
-    });
+  it('new player modal should focus input after delay', async () => {
+    showModal('new-player-modal');
+    await delay(60);
+    const input = document.getElementById('new-player-input');
+    assert.strictEqual(document.activeElement, input);
+  });
 
-    test('new player modal should focus input after delay', () => {
-        jest.useFakeTimers();
-        showModal('new-player-modal');
-        jest.advanceTimersByTime(60);
-        const input = document.getElementById('new-player-input');
-        expect(document.activeElement).toBe(input);
-        jest.useRealTimers();
-    });
+  it('new player modal should focus input immediately in standalone mode', () => {
+    global.window.matchMedia = () => ({ matches: true });
+    showModal('new-player-modal');
+    const input = document.getElementById('new-player-input');
+    assert.strictEqual(document.activeElement, input);
+  });
 
-    test('new player modal should focus input immediately in standalone mode', () => {
-        window.matchMedia = jest.fn().mockReturnValue({ matches: true });
-        showModal('new-player-modal');
-        const input = document.getElementById('new-player-input');
-        expect(document.activeElement).toBe(input);
-    });
+  it('should show an input error', () => {
+    showInputError('Test error');
+    const err = document.getElementById('new-player-error');
+    assert.ok(err);
+    assert.strictEqual(err.textContent, 'Test error');
+  });
 
-    test('should show an input error', () => {
-        showInputError('Test error');
-        const error = document.getElementById('new-player-error');
-        expect(error).not.toBeNull();
-        expect(error.textContent).toBe('Test error');
-    });
+  it('should clear an input error', () => {
+    showInputError('Test error');
+    clearInputError();
+    assert.strictEqual(document.getElementById('new-player-error'), null);
+  });
 
-    test('should clear an input error', () => {
-        showInputError('Test error');
-        clearInputError();
-        const error = document.getElementById('new-player-error');
-        expect(error).toBeNull();
-    });
+  it('commander damage indicator updates', () => {
+    state.players = ['Alice'];
+    state.playerState = { 'Alice': { life: 40, poison: 0, dead: false } };
+    state.commanderDamage = { 'Alice': { Bob: 0 } };
+    updateCurrentGamePlayersUI();
+    const btn = document.querySelector('.commander-damage-btn');
+    assert.strictEqual(btn.classList.contains('has-commander-damage'), false);
+    state.commanderDamage['Alice'].Bob = 5;
+    updateCommanderDamageIndicator('Alice');
+    assert.strictEqual(btn.classList.contains('has-commander-damage'), true);
+  });
 
-    test('commander damage indicator updates', () => {
-        state.players = ['Alice'];
-        state.playerState = { 'Alice': { life: 40, poison: 0, dead: false } };
-        state.commanderDamage = { 'Alice': { Bob: 0 } };
-        updateCurrentGamePlayersUI();
-        const btn = document.querySelector('.commander-damage-btn');
-        expect(btn.classList.contains('has-commander-damage')).toBe(false);
-        state.commanderDamage['Alice'].Bob = 5;
-        updateCommanderDamageIndicator('Alice');
-        expect(btn.classList.contains('has-commander-damage')).toBe(true);
-    });
+  it('should update the add player button visibility', () => {
+    state.gameEnded = true;
+    updateAddPlayerBtnVisibility();
+    const btn = document.getElementById('add-player-btn');
+    assert.strictEqual(btn.style.display, 'none');
+  });
 
-    test('should update the add player button visibility', () => {
-        state.gameEnded = true;
-        updateAddPlayerBtnVisibility();
-        const btn = document.getElementById('add-player-btn');
-        expect(btn.style.display).toBe('none');
-    });
-
-    test('should display winner state after reload', () => {
-        state.players = ['Alice', 'Bob'];
-        state.playerState = {
-            'Alice': { life: 20, poison: 0, dead: false },
-            'Bob': { life: 15, poison: 0, dead: false },
-        };
-        state.gameEnded = true;
-        state.winner = 'Alice';
-        updateCurrentGamePlayersUI();
-        const tiles = document.getElementById('player-tiles').children;
-        const aliceTile = Array.from(tiles).find(t => t.dataset.player === 'Alice');
-        const bobTile = Array.from(tiles).find(t => t.dataset.player === 'Bob');
-        expect(aliceTile.classList.contains('winner-tile')).toBe(true);
-        expect(aliceTile.classList.contains('game-ended')).toBe(true);
-        expect(bobTile.classList.contains('winner-tile')).toBe(false);
-        expect(bobTile.classList.contains('game-ended')).toBe(true);
-        Array.from(aliceTile.querySelectorAll('button')).forEach(btn => {
-            expect(btn.disabled).toBe(true);
-        });
-    });
+  it('should display winner state after reload', () => {
+    state.players = ['Alice', 'Bob'];
+    state.playerState = {
+      Alice: { life: 20, poison: 0, dead: false },
+      Bob: { life: 15, poison: 0, dead: false },
+    };
+    state.gameEnded = true;
+    state.winner = 'Alice';
+    updateCurrentGamePlayersUI();
+    const tiles = document.getElementById('player-tiles').children;
+    let aliceTile, bobTile;
+    for (const t of tiles) {
+      if (t.dataset.player === 'Alice') aliceTile = t;
+      if (t.dataset.player === 'Bob') bobTile = t;
+    }
+    assert.ok(aliceTile.classList.contains('winner-tile'));
+    assert.ok(aliceTile.classList.contains('game-ended'));
+    assert.ok(!bobTile.classList.contains('winner-tile'));
+    assert.ok(bobTile.classList.contains('game-ended'));
+    for (const btn of aliceTile.querySelectorAll('button')) {
+      assert.strictEqual(btn.disabled, true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- replace Jest setup with Node's built-in test runner
- add minimal DOM implementation for UI unit tests
- rewrite state and UI tests to use `node:test`
- run tests with `node --test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d1c5b78d4832e9e26afc8a70edd3c