### PR TITLE
Update commander damage color

### DIFF
--- a/style.css
+++ b/style.css
@@ -778,7 +778,7 @@ button:active {
 .commander-damage-value {
   font-size: 1.2em;
   font-weight: 700;
-  color: #e11d48;
+  color: var(--color-header);
   min-width: 2em;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- use the standard font color for commander damage values instead of red

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_687d1db11028832e93bad522c0859d0c