### PR TITLE
Fix poison modal button color

### DIFF
--- a/style.css
+++ b/style.css
@@ -802,7 +802,7 @@ button:active {
 }
 
 .poison-counter-btn {
-  background: var(--color-poison);
+  background: var(--color-btn);
   color: #fff;
   border: none;
   border-radius: 50%;
@@ -818,7 +818,7 @@ button:active {
 }
 .poison-counter-btn:hover,
 .poison-counter-btn:focus {
-  background: #ca8a04;
+  background: #2563eb;
   transform: scale(1.08);
 }
 


### PR DESCRIPTION
## Summary
- align poison modal plus/minus buttons with standard button color

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_687d1de0a944832e999dcd1a23a6fa18