### PR TITLE
Normalize life totals before updates

### DIFF
--- a/events.js
+++ b/events.js
@@ -90,7 +90,8 @@ async function declareWinner(playerName) {
 }
 
 function updatePlayerLife(playerName, delta) {
-    let life = state.playerState[playerName].life + delta;
+    const currentLife = Number(state.playerState[playerName].life);
+    let life = (Number.isFinite(currentLife) ? currentLife : 0) + delta;
     if (life < 0) life = 0;
     if (life > 999) life = 999;
     state.playerState[playerName].life = life;


### PR DESCRIPTION
### Motivation
- Player life updates could behave incorrectly when stored life totals were non-numeric (e.g., strings), causing concatenation instead of arithmetic when applying deltas. 
- The change ensures the app consistently treats stored life totals as numbers before modifying them. 

### Description
- Coerce and validate the stored life total in the `updatePlayerLife` function by using `Number(...)` and `Number.isFinite(...)` before applying `delta`. 
- This change is implemented in `events.js` inside `updatePlayerLife` (see `events.js` lines ~92-106). 

### Testing
- Ran `npm test` after the change. 
- All automated tests passed: 22 tests, 0 failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69600f0ce7d4832ea4335265530272a6)